### PR TITLE
fix: Remove erroring key from expense

### DIFF
--- a/splitwise/__init__.py
+++ b/splitwise/__init__.py
@@ -552,6 +552,7 @@ class Splitwise(object):
         category = expense.getCategory()
         if category:
             expense_data["category_id"] = category.getId()
+            del expense_data["category"]
 
         receipt = expense.getReceiptPath()
         files = None


### PR DESCRIPTION
Recently, Splitwise API started throwing Bad Request [400] error when the payload still contains **category** key. This PR removes the problematic/unnecessary key from payload which resolves the error.
Signed-off-by: Preetham <kamidipreetham@gmail.com>
